### PR TITLE
Make XML <state state="open|closed"> available on Service object

### DIFF
--- a/Net/Nmap/Parser.php
+++ b/Net/Nmap/Parser.php
@@ -105,13 +105,15 @@ class Net_Nmap_Parser extends XML_Parser
             $this->_service->protocol = @$attribs['protocol'];
             $this->_service->port     = @$attribs['portid'];
             break;
+        case 'state':
+            $this->_service->state    = @$attribs['state'];
         case 'service':
             $this->_service->name      = @$attribs['name'];
             $this->_service->product   = @$attribs['product'];
             $this->_service->version   = @$attribs['version'];
             $this->_service->extrainfo = @$attribs['extrainfo'];
             if (isset($attribs['ostype'])) {
-                $this->_host->addOS('0', $attribs['ostype']);                 
+                $this->_host->addOS('0', $attribs['ostype']);
             }
             break;
         case 'osmatch':

--- a/Net/Nmap/Parser.php
+++ b/Net/Nmap/Parser.php
@@ -107,6 +107,7 @@ class Net_Nmap_Parser extends XML_Parser
             break;
         case 'state':
             $this->_service->state    = @$attribs['state'];
+            break;
         case 'service':
             $this->_service->name      = @$attribs['name'];
             $this->_service->product   = @$attribs['product'];

--- a/Net/Nmap/Service.php
+++ b/Net/Nmap/Service.php
@@ -40,7 +40,8 @@ require_once 'Net/Nmap/Exception.php';
  * @property string $version   The version of the product running as service.
  * @property string $extrainfo The additional information about the product
  *                             running as service.
- * 
+ * @property string $state     Whether the port is open/closed
+ *
  * @category  Net
  * @package   Net_Nmap
  * @author    Luca Corbo <lucor@ortro.net>
@@ -60,13 +61,14 @@ class Net_Nmap_Service
                                                   'port' => null,
                                                   'name' => null,
                                                   'version'  => null,
-                                                  'extrainfo'  => null);
-    
+                                                  'extrainfo'  => null,
+                                                  'state' => null);
+
     /**
      * Overloading of the __get method
      *
      * @param string $key The name of the variable that should be retrieved
-     * 
+     *
      * @throws Net_Nmap_Exception If trying to get an undefined properties.
      * @return mixed The value of the object on success
      */


### PR DESCRIPTION
The scan returns incorrect results with closed ports being reported regardless. There's more that could be done here, including adding a "include closed" option to the scan and trim the results based on whether closed shows in the state. This fix simply adds the "state" property to the service object so the library user can check what the state is. 

A little whitespace editing slipped through my editor sorry for that mess.